### PR TITLE
Fix add project tests and editcommandparser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -52,7 +52,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         // Check for duplicate prefixes
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_DISCORD, PREFIX_LINKEDIN, PREFIX_INSTAGRAM, PREFIX_YOUTUBE, PREFIX_ADDRESS);
+                PREFIX_DISCORD, PREFIX_LINKEDIN, PREFIX_INSTAGRAM, PREFIX_YOUTUBE, PREFIX_ADDRESS, PREFIX_PRIORITY);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 

--- a/src/test/java/seedu/address/logic/commands/AddProjectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddProjectCommandTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -32,7 +36,7 @@ public class AddProjectCommandTest {
     // -------------------- execute() --------------------
 
     @Test
-    void execute_noMembers_success() throws Exception {
+    void execute_noMembers_throwsCommandException() throws Exception {
         String name = "IndiDex v1.3";
         LocalDate deadline = LocalDate.of(2025, 12, 31);
         Priority priority = Priority.HIGH;
@@ -41,12 +45,8 @@ public class AddProjectCommandTest {
         AddProjectCommand cmd = new AddProjectCommand(name, deadline, priority, members);
         ModelStubAcceptingProjectAdded model = new ModelStubAcceptingProjectAdded();
 
-        CommandResult result = cmd.execute(model);
-
-        Project expectedProject = new Project(name, priority, deadline, java.util.Set.of());
-        assertEquals(String.format("New project added: %s", expectedProject), result.getFeedbackToUser());
-        assertEquals(1, model.added.size());
-        assertEquals(expectedProject, model.added.get(0));
+        CommandException ex = assertThrows(CommandException.class, () -> cmd.execute(model));
+        assertEquals("Project must have at least one member.", ex.getMessage());
     }
 
     @Test
@@ -55,7 +55,7 @@ public class AddProjectCommandTest {
                 "SameName",
                 Priority.LOW,
                 LocalDate.of(2026, 1, 1),
-                java.util.Set.of()
+                java.util.Set.of(ALICE)
         );
         Model model = new ModelStubWithProject(existing);
 
@@ -63,7 +63,7 @@ public class AddProjectCommandTest {
                 "SameName", // same identity -> duplicate
                 LocalDate.of(2027, 2, 2),
                 Priority.HIGH,
-                List.of()
+                List.of(INDEX_SECOND_PERSON)
         );
 
         CommandException ex = assertThrows(CommandException.class, () -> cmd.execute(model));
@@ -77,7 +77,7 @@ public class AddProjectCommandTest {
                 "Proj",
                 LocalDate.of(2025, 10, 1),
                 Priority.MEDIUM,
-                List.of(Index.fromOneBased(1))
+                List.of(INDEX_FIRST_PERSON)
         );
 
         CommandException ex = assertThrows(CommandException.class, () -> cmd.execute(model));
@@ -286,6 +286,9 @@ public class AddProjectCommandTest {
 
         private ModelStubWithProject(Project existing) {
             this.existing = existing;
+
+            persons.add(ALICE);
+            persons.add(BOB);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/parser/AddProjectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddProjectCommandParserTest.java
@@ -47,12 +47,12 @@ class AddProjectCommandParserTest {
 
     @Test
     void parseNameTrimmed_success() throws Exception {
-        String input = " n/   MyProj   d/2025-10-01 pr/LOW";
+        String input = " n/   MyProj   m/1 d/2025-10-01 pr/LOW";
         AddProjectCommand expected = new AddProjectCommand(
                 "MyProj",
                 LocalDate.of(2025, 10, 1),
                 Priority.LOW,
-                List.of() // no members provided
+                List.of(Index.fromOneBased(1)) // no members provided
         );
 
         AddProjectCommand actual = parser.parse(input);


### PR DESCRIPTION
Add project tests edited to follow compulsory member rule

Edit command does not allow duplicate /pr prefixes