### PR TITLE
Fix tagcommand bug

### DIFF
--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -36,7 +36,11 @@ public class TagCommandParser implements Parser<TagCommand> {
         List<String> indexStrings = Arrays.asList(preamble.trim().split("\\s+"));
         List<Index> indexes = new ArrayList<>();
         for (String s : indexStrings) {
-            indexes.add(ParserUtil.parseIndex(s));
+            Index toAdd = ParserUtil.parseIndex(s);
+            if (indexes.contains(toAdd)) {
+                continue;
+            }
+            indexes.add(toAdd);
         }
 
         Set<Tag> tags = ParserUtil.parseTags(argumentMultimap.getAllValues(CliSyntax.PREFIX_TAG));


### PR DESCRIPTION
When same index is input twice (eg. tag 1 2 3 2 1 t/friend) duplicates are not counted in output (ie. added to 3 not 5 in the example